### PR TITLE
TINF-59: Backend Deployment an neue Struktur anpassen (1/2)

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -3,7 +3,7 @@ name: Development
 on:
   push:
     branches:
-      - master
+      - develop
 
 jobs:
   build:


### PR DESCRIPTION
Damit das automatische Deployment wieder funktioniert, würde ich das Deployment für die `development` und die `production` Umgebung wiederherstellen ohne eine Integrationsumgebung einzuführen, da diese auch unabhängig eingeführt werden kann, da hier noch ein paar Fragen zu klären sind.