### PR TITLE
TINF-223: Lokales Nominatim gibt immer HTTP 406 zurück

### DIFF
--- a/src/main/java/de/sakpaas/backend/service/LocationService.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationService.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -77,10 +80,15 @@ public class LocationService {
    */
   public List<Location> search(String key) {
     // Makes a request to the Nominatim Microservice
+
     final String url = this.searchApiUrl + "/search/" + key + "?format=json";
     RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.set(HttpHeaders.ACCEPT, "text/html");
+    HttpEntity<String> entityReq = new HttpEntity<String>(httpHeaders);
     ResponseEntity<NominatimSearchResultListDto> response =
-        restTemplate.getForEntity(url, NominatimSearchResultListDto.class);
+        restTemplate.exchange(url, HttpMethod.GET, entityReq, NominatimSearchResultListDto.class);
+
 
     if (response.getBody() == null) {
       return Collections.emptyList();

--- a/src/main/java/de/sakpaas/backend/service/LocationService.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationService.java
@@ -84,7 +84,8 @@ public class LocationService {
     final String url = this.searchApiUrl + "/search/" + key + "?format=json";
     RestTemplate restTemplate = new RestTemplate();
     HttpHeaders httpHeaders = new HttpHeaders();
-    httpHeaders.set(HttpHeaders.ACCEPT, "text/html");
+    // Nominatim kommt wohl nicht auf "application/json" klar.
+    httpHeaders.set(HttpHeaders.ACCEPT, "test/html");
     HttpEntity<String> entityReq = new HttpEntity<String>(httpHeaders);
     ResponseEntity<NominatimSearchResultListDto> response =
         restTemplate.exchange(url, HttpMethod.GET, entityReq, NominatimSearchResultListDto.class);

--- a/src/main/java/de/sakpaas/backend/service/LocationService.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationService.java
@@ -85,7 +85,7 @@ public class LocationService {
     RestTemplate restTemplate = new RestTemplate();
     HttpHeaders httpHeaders = new HttpHeaders();
     // Nominatim kommt wohl nicht auf "application/json" klar.
-    httpHeaders.set(HttpHeaders.ACCEPT, "test/html");
+    httpHeaders.set(HttpHeaders.ACCEPT, "text/html");
     HttpEntity<String> entityReq = new HttpEntity<String>(httpHeaders);
     ResponseEntity<NominatimSearchResultListDto> response =
         restTemplate.exchange(url, HttpMethod.GET, entityReq, NominatimSearchResultListDto.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     driver-class-name: org.postgresql.Driver
 
 app:
-  search-api-url: https://nominatim.openstreetmap.org
+  search-api-url: http://localhost
   presence:
     duration: 20
   occupancy:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     driver-class-name: org.postgresql.Driver
 
 app:
-  search-api-url: http://localhost
+  search-api-url: https://nominatim.openstreetmap.org/
   presence:
     duration: 20
   occupancy:


### PR DESCRIPTION
Das lokale Deployment von Nominatim hat bei jeder Anfrage des Backends den HTTP Fehler 406 zurück zu geben. Dieser Fehler ließ sich auf einen Fehlenden HTTP Header zurück zu führen. Dieser wird in diesem PR gesetzt.

Es wurden keine Tests geschrieben, da die Methode von @Mavv3006 aktuell überarbeitet und in eine Klasse umgelagert wird.