### PR TITLE
TINF-288: Applikation startet lokal nicht ohne Keycloak

### DIFF
--- a/src/main/java/de/sakpaas/backend/exception/NoKeycloakDeploymentException.java
+++ b/src/main/java/de/sakpaas/backend/exception/NoKeycloakDeploymentException.java
@@ -1,0 +1,19 @@
+package de.sakpaas.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception that is used in order to display that the given Bearer Token is invalid.
+ */
+public class NoKeycloakDeploymentException extends ApplicationException {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final String TEXT_ID = "NO_KEYCLOAK_DEPLOYMENT";
+  private static final String MESSAGE =
+      "This server has no valid KeyCloak deployment. We can not answer your request.";
+
+  public NoKeycloakDeploymentException() {
+    super(HttpStatus.SERVICE_UNAVAILABLE, MESSAGE, TEXT_ID, false);
+  }
+}

--- a/src/main/java/de/sakpaas/backend/service/UserService.java
+++ b/src/main/java/de/sakpaas/backend/service/UserService.java
@@ -40,15 +40,21 @@ public class UserService {
    *
    * @param header Authorization Header from the Request
    * @return UserInformationDto
-   * @throws InvalidBearerTokenException If the given Authentication Header does not container a
-   *                                     valid Bearer Token, this exception will be thrown.
+   * @throws InvalidBearerTokenException If the given Authentication Header is null or does not
+   *                                     container a valid Bearer Token, this exception will be
+   *                                     thrown.
    */
   public UserInfoDto getUserInfo(String header) throws InvalidBearerTokenException {
-    try {
-      // Split token from "Bearer token" string
-      String token =
-          TokenUtils.getTokenFromHeader(header).orElseThrow(InvalidBearerTokenException::new);
+    // If no header is set, we can not parse the JWT and we should fail
+    if (header == null) {
+      throw new InvalidBearerTokenException();
+    }
 
+    // Extract token from "Bearer TOKEN" string or fail
+    String token = TokenUtils.getTokenFromHeader(header)
+        .orElseThrow(InvalidBearerTokenException::new);
+
+    try {
       // Validate and parse token
       AccessToken jwt = verifyToken(token);
 

--- a/src/main/java/de/sakpaas/backend/service/UserService.java
+++ b/src/main/java/de/sakpaas/backend/service/UserService.java
@@ -3,6 +3,7 @@ package de.sakpaas.backend.service;
 import com.google.common.annotations.VisibleForTesting;
 import de.sakpaas.backend.dto.UserInfoDto;
 import de.sakpaas.backend.exception.InvalidBearerTokenException;
+import de.sakpaas.backend.exception.NoKeycloakDeploymentException;
 import de.sakpaas.backend.util.KeycloakConfiguration;
 import de.sakpaas.backend.util.TokenUtils;
 import java.util.Optional;
@@ -64,10 +65,18 @@ public class UserService {
     }
   }
 
+  /**
+   *
+   * @param token
+   * @return
+   * @throws VerificationException
+   */
   @VisibleForTesting
   AccessToken verifyToken(String token) throws VerificationException {
     return AdapterTokenVerifier.verifyToken(
         token,
-        keycloakConfiguration.getKeycloakDeployment());
+        keycloakConfiguration.getKeycloakDeployment()
+            .orElseThrow(NoKeycloakDeploymentException::new)
+    );
   }
 }

--- a/src/main/java/de/sakpaas/backend/service/UserService.java
+++ b/src/main/java/de/sakpaas/backend/service/UserService.java
@@ -66,10 +66,11 @@ public class UserService {
   }
 
   /**
+   * Verifies and parses the given JWT.
    *
-   * @param token
-   * @return
-   * @throws VerificationException
+   * @param token the JWT to verify and parse
+   * @return the parsed {@link AccessToken}
+   * @throws VerificationException iff the given JWT is invalid
    */
   @VisibleForTesting
   AccessToken verifyToken(String token) throws VerificationException {

--- a/src/main/java/de/sakpaas/backend/util/KeycloakConfiguration.java
+++ b/src/main/java/de/sakpaas/backend/util/KeycloakConfiguration.java
@@ -1,6 +1,6 @@
 package de.sakpaas.backend.util;
 
-import lombok.Getter;
+import java.util.Optional;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.KeycloakDeploymentBuilder;
 import org.keycloak.adapters.spi.HttpFacade;
@@ -9,16 +9,40 @@ import org.keycloak.adapters.springboot.KeycloakSpringBootProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
-@Getter
 @Configuration
 public class KeycloakConfiguration extends KeycloakSpringBootConfigResolver {
-  private final KeycloakDeployment keycloakDeployment;
 
+  private KeycloakDeployment keycloakDeployment;
+
+  /**
+   * Creates a new {@link KeycloakConfiguration} with the {@link KeycloakSpringBootProperties}, if
+   * they are available.
+   *
+   * @param properties the {@link KeycloakSpringBootProperties}
+   */
   public KeycloakConfiguration(
-      @Autowired(required = false) KeycloakSpringBootProperties properties) {
-    keycloakDeployment = KeycloakDeploymentBuilder.build(properties);
+      @Autowired(required = false) KeycloakSpringBootProperties properties
+  ) {
+    keycloakDeployment = (properties != null)
+        ? KeycloakDeploymentBuilder.build(properties)
+        : null;
   }
 
+  /**
+   * Returns the current {@link KeycloakDeployment} if there is one available.
+   *
+   * @return the current {@link KeycloakDeployment}
+   */
+  public Optional<KeycloakDeployment> getKeycloakDeployment() {
+    return Optional.ofNullable(keycloakDeployment);
+  }
+
+  /**
+   * Returns the current {@link KeycloakDeployment} for the given {@link HttpFacade.Request}.
+   *
+   * @param facade the {@link HttpFacade.Request}
+   * @return the {@link KeycloakDeployment}
+   */
   @Override
   public KeycloakDeployment resolve(HttpFacade.Request facade) {
     return keycloakDeployment;

--- a/src/main/java/de/sakpaas/backend/util/KeycloakConfiguration.java
+++ b/src/main/java/de/sakpaas/backend/util/KeycloakConfiguration.java
@@ -6,6 +6,7 @@ import org.keycloak.adapters.KeycloakDeploymentBuilder;
 import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
 import org.keycloak.adapters.springboot.KeycloakSpringBootProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
 @Getter
@@ -13,7 +14,8 @@ import org.springframework.context.annotation.Configuration;
 public class KeycloakConfiguration extends KeycloakSpringBootConfigResolver {
   private final KeycloakDeployment keycloakDeployment;
 
-  public KeycloakConfiguration(KeycloakSpringBootProperties properties) {
+  public KeycloakConfiguration(
+      @Autowired(required = false) KeycloakSpringBootProperties properties) {
     keycloakDeployment = KeycloakDeploymentBuilder.build(properties);
   }
 


### PR DESCRIPTION
Der Bug ist grundsätzlich gefixt, folgende Auswirkungen gibt es:
* Wenn ein Endpunkt **NUR** durch die `application.yaml` geschützt ist, geht die Anfrage **OHNE** Authentifizierung durch.
* Wenn der Programm Code einen `Authentication` **SELBST** parst, dann schlägt die Anfrage mit `503 NO_KEYCLOAK_DEPLOYMENT` **FEHL**.
* Wenn der Programm Code einen `Authentication` **SELBST** parst **UND** durch die `application.yaml` geschützt ist, schlägt die Anfrage bei fehlendem `Authentication`-Header mit `400` statt mit `401` fehl.