### PR TITLE
Bugfix/TINF-355: Code 400 & IllegalArgumentException

### DIFF
--- a/src/main/java/de/sakpaas/backend/service/SearchMappingService.java
+++ b/src/main/java/de/sakpaas/backend/service/SearchMappingService.java
@@ -5,6 +5,7 @@ import de.sakpaas.backend.dto.NominatimSearchResultListDto;
 import de.sakpaas.backend.model.CoordinateDetails;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.net.URI;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,7 +24,7 @@ public class SearchMappingService {
   private final RestTemplate restTemplate;
   private final MeterRegistry meterRegistry;
 
-  protected String url;
+  protected URI url;
 
   @Value("${app.search-api-url}")
   private String searchApiUrl;
@@ -71,11 +72,10 @@ public class SearchMappingService {
    * @param query The search parameter
    */
   private void buildUrl(Set<String> query) {
-    this.url = UriComponentsBuilder.fromHttpUrl(this.searchApiUrl)
-        .queryParam("q", query)
+    this.url = UriComponentsBuilder.fromHttpUrl(this.searchApiUrl + "search/")
+        .queryParam("q", String.join(",", query))
         .queryParam("limit", 1)
-        .queryParam("format", "json")
-        .toUriString();
+        .queryParam("format", "json").build(false).toUri();
   }
 
   /**
@@ -88,11 +88,10 @@ public class SearchMappingService {
     String urlQuery = String.join(",", query) + "," + coordinateDetails.getLatitude() + ","
         + coordinateDetails.getLongitude();
 
-    this.url = UriComponentsBuilder.fromHttpUrl(this.searchApiUrl)
+    this.url = UriComponentsBuilder.fromHttpUrl(this.searchApiUrl + "search/")
         .queryParam("q", urlQuery)
         .queryParam("limit", 1)
-        .queryParam("format", "json")
-        .toUriString();
+        .queryParam("format", "json").build(false).toUri();
   }
 
   /**

--- a/src/test/java/de/sakpaas/backend/service/SearchMappingServiceTest.java
+++ b/src/test/java/de/sakpaas/backend/service/SearchMappingServiceTest.java
@@ -75,14 +75,14 @@ class SearchMappingServiceTest extends HappyHamsterTest {
 
     String responseBody =
         "[{\"place_id\":97754986,\"licence\":\"Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright\",\"osm_type\":\"way\",\"osm_id\":45186996,\"boundingbox\":[\"49.3188712\",\"49.3191267\",\"9.3630305\",\"9.3637289\"],\"lat\":\"49.3190277\",\"lon\":\"9.363421444681375\",\"display_name\":\"Lidl, 10, Daimlerstraße, Schillerhöhe, Möckmühl, Verwaltungsgemeinschaft Möckmühl, Landkreis Heilbronn, Baden-Württemberg, 74219, Germany\",\"class\":\"shop\",\"type\":\"supermarket\",\"importance\":0.22100000000000003,\"icon\":\"https://nominatim.openstreetmap.org/images/mapicons/shopping_supermarket.p.20.png\"}]";
-    mockServer.expect(ExpectedCount.once(), requestTo(new URI("/test.de")))
+    mockServer.expect(ExpectedCount.once(), requestTo(new URI("test.de")))
         .andExpect(method(HttpMethod.GET))
         .andExpect(header(HttpHeaders.ACCEPT, "text/html"))
         .andRespond(withStatus(HttpStatus.OK)
             .contentType(MediaType.APPLICATION_JSON)
             .body(responseBody));
 
-    searchMappingService.url = "test.de";
+    searchMappingService.url = new URI("test.de");
 
     NominatimSearchResultListDto nominatimSearchResultListDto =
         searchMappingService.makeRequest();


### PR DESCRIPTION
Um detaillierte Informationen über den Bug zu bekommen, siehe [Jira](https://pw-netz.atlassian.net/browse/TINF-355).

Um diesen Bug zu testen, bitte im Debug-Modus, am Ende der `getCoordinatesFromNominatim()` Methode im SearchService einen Breakpoint setzen. Ansonsten sieht man noch den [anderen Bug](https://github.com/SAKPaaS/backend/pull/150), um den es hier nicht geht.