### PR TITLE
TINF-333: Location Types Endpoint

### DIFF
--- a/src/main/java/de/sakpaas/backend/service/LocationDetailsRepository.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationDetailsRepository.java
@@ -1,11 +1,16 @@
 package de.sakpaas.backend.service;
 
 import de.sakpaas.backend.model.LocationDetails;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LocationDetailsRepository extends JpaRepository<LocationDetails, Long> {
 
   Optional<LocationDetails> findById(Long id);
+
+  @Query(value = "SELECT type FROM location_details GROUP BY type", nativeQuery = true)
+  List<String> getAllLocationTypes();
 
 }

--- a/src/main/java/de/sakpaas/backend/service/LocationDetailsRepository.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationDetailsRepository.java
@@ -10,7 +10,7 @@ public interface LocationDetailsRepository extends JpaRepository<LocationDetails
 
   Optional<LocationDetails> findById(Long id);
 
-  @Query(value = "SELECT type FROM location_details GROUP BY type", nativeQuery = true)
+  @Query(value = "SELECT DISTINCT type FROM location_details", nativeQuery = true)
   List<String> getAllLocationTypes();
 
 }

--- a/src/main/java/de/sakpaas/backend/service/LocationService.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationService.java
@@ -16,21 +16,25 @@ public class LocationService {
   private final LocationRepository locationRepository;
   private final PresenceRepository presenceRepository;
   private final OccupancyRepository occupancyRepository;
+  private final LocationDetailsRepository locationDetailsRepository;
   private final FavoriteService favoriteService;
 
   /**
    * Default Constructor. Handles the Dependency Injection and Meter Initialisation and Registering
    *
-   * @param locationRepository The Location Repository
+   * @param locationRepository        The Location Repository
+   * @param locationDetailsRepository
    */
   @Autowired
   public LocationService(LocationRepository locationRepository,
                          PresenceRepository presenceRepository,
                          OccupancyRepository occupancyRepository,
+                         LocationDetailsRepository locationDetailsRepository,
                          FavoriteService favoriteService) {
     this.locationRepository = locationRepository;
     this.presenceRepository = presenceRepository;
     this.occupancyRepository = occupancyRepository;
+    this.locationDetailsRepository = locationDetailsRepository;
     this.favoriteService = favoriteService;
   }
 
@@ -63,6 +67,7 @@ public class LocationService {
         .limit(100)
         .collect(Collectors.toList());
   }
+
 
   /**
    * Gets all Locations from a specific coordinate.
@@ -113,5 +118,14 @@ public class LocationService {
     presenceRepository.findByLocation(location).forEach(presenceRepository::delete);
     favoriteService.deleteByLocation(location);
     locationRepository.delete(location);
+  }
+
+  /**
+   * Gets all Location Types from the Database and returns them.
+   *
+   * @return All existing location types
+   */
+  public List<String> getAllLocationTypes() {
+    return locationDetailsRepository.getAllLocationTypes();
   }
 }

--- a/src/main/java/de/sakpaas/backend/service/LocationService.java
+++ b/src/main/java/de/sakpaas/backend/service/LocationService.java
@@ -23,7 +23,7 @@ public class LocationService {
    * Default Constructor. Handles the Dependency Injection and Meter Initialisation and Registering
    *
    * @param locationRepository        The Location Repository
-   * @param locationDetailsRepository
+   * @param locationDetailsRepository The Location Details Repository
    */
   @Autowired
   public LocationService(LocationRepository locationRepository,

--- a/src/main/java/de/sakpaas/backend/v2/controller/LocationController.java
+++ b/src/main/java/de/sakpaas/backend/v2/controller/LocationController.java
@@ -47,6 +47,7 @@ public class LocationController {
   private static final String MAPPING_BY_ID = "/{locationId}";
   private static final String MAPPING_START_DATABASE = "/generate/{key}";
   private static final String MAPPING_SEARCH_LOCATION = "/search/{key}";
+  private static final String MAPPING_LOCATION_TYPES = "/types";
   private final LocationService locationService;
   private final SearchService searchService;
   private final OpenStreetMapService openStreetMapService;
@@ -230,5 +231,15 @@ public class LocationController {
         .orElseGet(
             () -> new ResponseEntity<>(searchResultMapper.mapSearchResultToOutputDto(resultObject),
                 OK));
+  }
+
+  /**
+   * Returns all existing Location Types.
+   *
+   * @return ResponseEntity with the Location Type List
+   */
+  @GetMapping(MAPPING_LOCATION_TYPES)
+  public ResponseEntity<List<String>> getAllLocationTypes() {
+    return new ResponseEntity<>(locationService.getAllLocationTypes(), OK);
   }
 }

--- a/src/test/java/de/sakpaas/backend/service/LocationDetailsRepositoryTest.java
+++ b/src/test/java/de/sakpaas/backend/service/LocationDetailsRepositoryTest.java
@@ -1,0 +1,45 @@
+package de.sakpaas.backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.sakpaas.backend.HappyHamsterTest;
+import de.sakpaas.backend.model.LocationDetails;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class LocationDetailsRepositoryTest extends HappyHamsterTest {
+
+  @Autowired
+  LocationDetailsRepository locationDetailsRepository;
+
+  @Test
+  void getAllLocationTypes() {
+    locationDetailsRepository.deleteAll();
+
+    assertThat(locationDetailsRepository.getAllLocationTypes().size()).isEqualTo(0);
+
+    locationDetailsRepository
+        .save(new LocationDetails("testType1", "testOpeningHours1", "testBrand1"));
+
+    assertThat(locationDetailsRepository.getAllLocationTypes().size()).isEqualTo(1);
+    assertThat(locationDetailsRepository.getAllLocationTypes().contains("testType1"));
+
+    locationDetailsRepository
+        .save(new LocationDetails("testType2", "testOpeningHours2", "testBrand2"));
+
+    assertThat(locationDetailsRepository.getAllLocationTypes().size()).isEqualTo(2);
+    assertThat(locationDetailsRepository.getAllLocationTypes().contains("testType1"));
+    assertThat(locationDetailsRepository.getAllLocationTypes().contains("testType2"));
+
+    locationDetailsRepository
+        .save(new LocationDetails("testType1", "testOpeningHours3", "testBrand3"));
+
+    assertThat(locationDetailsRepository.getAllLocationTypes().size()).isEqualTo(2);
+    assertThat(locationDetailsRepository.getAllLocationTypes().contains("testType1"));
+    assertThat(locationDetailsRepository.getAllLocationTypes().contains("testType2"));
+
+    locationDetailsRepository.deleteAll();
+  }
+}

--- a/src/test/java/de/sakpaas/backend/v2/controller/LocationControllerTest.java
+++ b/src/test/java/de/sakpaas/backend/v2/controller/LocationControllerTest.java
@@ -1,0 +1,57 @@
+package de.sakpaas.backend.v2.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.sakpaas.backend.HappyHamsterTest;
+import de.sakpaas.backend.service.LocationService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@EnableConfigurationProperties
+class LocationControllerTest extends HappyHamsterTest {
+
+  @MockBean
+  LocationService locationService;
+  @Autowired
+  private MockMvc mvc;
+
+  @SneakyThrows
+  @Test
+  void getLocationTypesTest() {
+    List<String> locationTypes = new ArrayList<>();
+    locationTypes.add("testType1");
+    locationTypes.add("testType2");
+
+    Mockito.when(locationService.getAllLocationTypes()).thenReturn(locationTypes);
+
+    String resultJson = mvc.perform(get("/v2/locations/types")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+
+    String compareJson = new ObjectMapper().writeValueAsString(locationTypes);
+    assertThat(compareJson, equalTo(resultJson));
+  }
+
+}


### PR DESCRIPTION
Ich habe einen neuen Endpoint angelegt, welcher alle in der Datenbank vorhandenen Location Types zurück gibt.

Ich habe sowohl für das Repository als auch den Controller Tests geschrieben. Die Implementierung im Service war trivial.

Der Endpunkt ist erreichbar unter /v2/locations/types